### PR TITLE
modify env template

### DIFF
--- a/charts/kube-node-init/templates/_helpers.tpl
+++ b/charts/kube-node-init/templates/_helpers.tpl
@@ -47,6 +47,18 @@ Environment template block for deployable resources
 */}}
 {{- define "node-init.env" -}}
 {{- $root := . -}}
+env:
+- name: NODE_NAME
+  valueFrom:
+    fieldRef:
+      fieldPath: spec.nodeName
+{{- with $root.Values.env }}
+{{- range $name, $value := . }}
+- name: {{ $name }}
+  value: {{ default "" $value | quote }}
+{{- end }}
+{{- end }}
+
 {{- if or .Values.configMaps $root.Values.secrets }}
 envFrom:
 {{- range $name, $config := $root.Values.configMaps -}}
@@ -66,13 +78,7 @@ envFrom:
 {{- end }}
 {{- end }}
 {{- end }}
-{{- with $root.Values.env }}
-env:
-{{- range $name, $value := . }}
-  - name: {{ $name }}
-    value: {{ default "" $value | quote }}
-{{- end }}
-{{- end }}
+
 {{- end -}}
 
 

--- a/charts/kube-node-init/templates/daemonset.yaml
+++ b/charts/kube-node-init/templates/daemonset.yaml
@@ -53,7 +53,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-          {{ include "node-init.env" . | indent 8 }}
+{{ include "node-init.env" . | indent 8 }}
         volumeMounts:
         - name: host-var
           mountPath: /host/var/

--- a/charts/kube-node-init/templates/daemonset.yaml
+++ b/charts/kube-node-init/templates/daemonset.yaml
@@ -53,10 +53,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        - name: TEST
-          value: HOGE
-
-{{ include "node-init.env" . | indent 8 }}
+          {{ include "node-init.env" . | indent 8 }}
         volumeMounts:
         - name: host-var
           mountPath: /host/var/

--- a/charts/kube-node-init/templates/daemonset.yaml
+++ b/charts/kube-node-init/templates/daemonset.yaml
@@ -53,6 +53,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: TEST
+          value: HOGE
+
 {{ include "node-init.env" . | indent 8 }}
         volumeMounts:
         - name: host-var

--- a/charts/kube-node-init/templates/daemonset.yaml
+++ b/charts/kube-node-init/templates/daemonset.yaml
@@ -48,11 +48,6 @@ spec:
         - /var/node-init/run
         resources:
 {{ toYaml .Values.resources | indent 12 }}
-        env:
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
 {{ include "node-init.env" . | indent 8 }}
         volumeMounts:
         - name: host-var

--- a/charts/kube-node-init/templates/daemonset.yaml
+++ b/charts/kube-node-init/templates/daemonset.yaml
@@ -53,7 +53,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-{{ include "node-init.env" . | indent 10 }}
+{{ include "node-init.env" . | indent 8 }}
         volumeMounts:
         - name: host-var
           mountPath: /host/var/


### PR DESCRIPTION
envに値をセットしても正しく展開されないのでindentを直してみました。

* 検証
values.yamlに以下追加
```
env:
  HOGE: "huga"
```

PR前のdiffの結果
```
          env:
          - name: NODE_NAME
            valueFrom:
              fieldRef:
                fieldPath: spec.nodeName

            envFrom:
+           env:
+             - name: HOGE
+               value: "huga"
```
`env:` の下にenvが入っており、正しくセットされない。
sync後、`edit ds kube-node-init`で該当箇所確認。
```
        env:
        - name: NODE_NAME
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: spec.nodeName
        image: mumoshu/kube-node-init:0.1.0
```

PRの修正後のdiffの結果
```
          env:
          - name: NODE_NAME
            valueFrom:
              fieldRef:
                fieldPath: spec.nodeName
+
+         envFrom:
+         env:
+           - name: HOGE
+             value: "huga"
```

`edit`コマンドで 確認
```
        env:
        - name: HAGE
          value: huga
```
追加した値は入っているが、元のvalueが入っていない。