### PR TITLE
modify secrets

### DIFF
--- a/charts/kube-node-init/templates/secrets.yaml
+++ b/charts/kube-node-init/templates/secrets.yaml
@@ -27,7 +27,7 @@ data:
 {{- end }}
 {{- end }}
 
-{{- if not (empty $secret.files) }}
+{{- if or (not (empty $secret.files)) (not (empty $secret.templates)) }}
 ---
 apiVersion: v1
 kind: Secret
@@ -52,6 +52,12 @@ data:
   {{ $key  }}: {{ $value | b64enc }}
 {{- end }}
 {{- end }}
+
+{{- range $key, $value := $secret.templates }}
+  {{ $key  }}: |
+{{ tpl $value $ | indent 4 }}
+{{- end }}
+
 {{- end }}
 
 {{- end }}


### PR DESCRIPTION
## 背景

valuesに以下のようにtemplateを渡してもmountされない
```
secrets:
  node-init:
    enabled: true
    mountPath: /var/node-init-test
    files:
      "hoge": |-
        echo "hoge"
    templates:
      "yea-script": |-
        echo "default script end"
```
filesは行ける

## やったこと

configmapsと比較して、templateを読み込む部分がsecretになかったので追加