### PR TITLE
Upgrade apiVersion

### DIFF
--- a/charts/kube-node-init/templates/daemonset.yaml
+++ b/charts/kube-node-init/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "node-init.fullname" . }}


### PR DESCRIPTION
kubernetes1.16以降ではDaemonSetでのextensions/v1beta1は提供されなくなるため、apps/v1に変更したいです。

参考: 
https://docs.aws.amazon.com/ja_jp/eks/latest/userguide/update-cluster.html#1-16-prequisites