### PR TITLE
add .spec.selector for requirement of v1.16

### DIFF
--- a/charts/kube-node-init/templates/daemonset.yaml
+++ b/charts/kube-node-init/templates/daemonset.yaml
@@ -8,6 +8,9 @@ metadata:
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "node-init.fullname" . }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
## changes

* `apiVersion: apps/v1` requires `.spec.selector` 


## FYI
https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/
<img width="830" alt="スクリーンショット 2020-06-23 19 11 44" src="https://user-images.githubusercontent.com/122267/85391633-651e8c00-b585-11ea-93a3-1173d81d418e.png">
